### PR TITLE
Adding azimuth carrier computation for bursts

### DIFF
--- a/src/sentinel1_reader/sentinel1_burst_slc.py
+++ b/src/sentinel1_reader/sentinel1_burst_slc.py
@@ -1,4 +1,4 @@
-import datetime as datetime
+import datetime
 from dataclasses import dataclass
 
 import isce3
@@ -30,8 +30,7 @@ def compute_az_carrier(burst, orbit, offset, position):
 
     # Get burst sensing mid relative to orbit reference epoch
     fmt = "%Y-%m-%dT%H:%M:%S.%f"
-    orbit_ref_epoch = datetime.datetime.strptime(orbit.reference_epoch.__str__()[:-3],
-                                        fmt)
+    orbit_ref_epoch = datetime.datetime.strptime(orbit.reference_epoch.__str__()[:-3], fmt)
 
     t_mid = burst.get_sensing_mid() - orbit_ref_epoch
     _, v = orbit.interpolate(t_mid.total_seconds())
@@ -257,12 +256,12 @@ class Sentinel1BurstSlc:
             fid.write(tmpl)
 
     def get_sensing_mid(self):
-        '''Returns sensing mid as datetime object.
+        '''Returns sensing mid as datetime.datetime object.
 
         Returns:
         --------
-        _ : datetime
-            Sensing mid as datetime object.
+        _ : datetime.datetime
+            Sensing mid as datetime.datetime object.
         '''
         d_seconds = 0.5 * (self.shape[0] - 1) * self.azimuth_time_interval
         return self.sensing_start + datetime.timedelta(seconds=d_seconds)

--- a/src/sentinel1_reader/sentinel1_burst_slc.py
+++ b/src/sentinel1_reader/sentinel1_burst_slc.py
@@ -1,4 +1,4 @@
-import datetime
+import datetime as datetime
 from dataclasses import dataclass
 
 import isce3
@@ -27,11 +27,10 @@ def compute_az_carrier(burst, orbit, offset, position):
     carr: np.ndarray
        Azimuth carrier
     '''
-    from datetime import datetime
 
     # Get burst sensing mid relative to orbit reference epoch
     fmt = "%Y-%m-%dT%H:%M:%S.%f"
-    orbit_ref_epoch = datetime.strptime(orbit.reference_epoch.__str__()[:-3],
+    orbit_ref_epoch = datetime.datetime.strptime(orbit.reference_epoch.__str__()[:-3],
                                         fmt)
 
     t_mid = burst.get_sensing_mid() - orbit_ref_epoch

--- a/src/sentinel1_reader/sentinel1_burst_slc.py
+++ b/src/sentinel1_reader/sentinel1_burst_slc.py
@@ -126,9 +126,9 @@ def polyfit(xin, yin, zin, azimuth_order, range_order,
     if snr is not None:
         A = A / snr[:, None]
         z = z / snr
-    return_val = True
 
-    val, res, rank, eigs = np.linalg.lstsq(A, z, rcond=cond)
+    return_val = True
+    val, res, _, eigs = np.linalg.lstsq(A, z, rcond=cond)
     if len(res) > 0:
         print('Chi squared: %f' % (np.sqrt(res / (1.0 * len(z)))))
     else:

--- a/src/sentinel1_reader/sentinel1_burst_slc.py
+++ b/src/sentinel1_reader/sentinel1_burst_slc.py
@@ -1,11 +1,9 @@
-from dataclasses import dataclass
-from datetime import datetime
 import datetime
-import numpy as np
-
-from osgeo import gdal
+from dataclasses import dataclass
 
 import isce3
+import numpy as np
+from osgeo import gdal
 
 
 # Other functionalities
@@ -29,6 +27,7 @@ def compute_az_carrier(burst, orbit, offset, position):
     carr: np.ndarray
        Azimuth carrier
     '''
+    from datetime import datetime
 
     # Get burst sensing mid relative to orbit reference epoch
     fmt = "%Y-%m-%dT%H:%M:%S.%f"
@@ -44,7 +43,7 @@ def compute_az_carrier(burst, orbit, offset, position):
 
     n_lines, _ = burst.shape
     eta = (y - (n_lines // 2) + offset) * burst.azimuth_time_interval
-    rng = burst.starting_range + x * burst.range_pxl_spacing
+    rng = burst.starting_range + x * burst.range_pixel_spacing
 
     f_etac = np.array(
         burst.doppler.poly1d.eval(rng.flatten().tolist())).reshape(rng.shape)

--- a/src/sentinel1_reader/sentinel1_burst_slc.py
+++ b/src/sentinel1_reader/sentinel1_burst_slc.py
@@ -1,9 +1,160 @@
 from dataclasses import dataclass
+from datetime import datetime
 import datetime
+import numpy as np
 
 from osgeo import gdal
 
 import isce3
+
+
+# Other functionalities
+def compute_az_carrier(burst, orbit, offset, position):
+    '''
+    Estimate azimuth carrier and store in numpy arrary
+
+    Parameters
+    ----------
+    burst: Sentinel1BurstSlc
+       Sentinel1 burst object
+    orbit: isce3.core.Orbit
+       Sentinel1 orbit ephemerides
+    offset: float
+       Offset between reference and secondary burst
+    position: tuple
+       Tuple of locations along y and x directions
+
+    Returns
+    -------
+    carr: np.ndarray
+       Azimuth carrier
+    '''
+
+    # Get burst sensing mid relative to orbit reference epoch
+    fmt = "%Y-%m-%dT%H:%M:%S.%f"
+    orbit_ref_epoch = datetime.strptime(orbit.reference_epoch.__str__()[:-3],
+                                        fmt)
+
+    t_mid = burst.get_sensing_mid() - orbit_ref_epoch
+    _, v = orbit.interpolate(t_mid.total_seconds())
+    vs = np.linalg.norm(v)
+    ks = 2 * vs * burst.azimuth_steer_rate / burst.wavelength
+
+    y, x = position
+
+    n_lines, _ = burst.shape
+    eta = (y - (n_lines // 2) + offset) * burst.azimuth_time_interval
+    rng = burst.starting_range + x * burst.range_pxl_spacing
+
+    f_etac = np.array(
+        burst.doppler.poly1d.eval(rng.flatten().tolist())).reshape(rng.shape)
+    ka = np.array(burst.azimuth_fm_rate.eval(rng.flatten().tolist())).reshape(
+        rng.shape)
+
+    eta_ref = (burst.doppler.poly1d.eval(
+        burst.starting_range) / burst.azimuth_fm_rate.eval(
+        burst.starting_range)) - (f_etac / ka)
+    kt = ks / (1.0 - ks / ka)
+
+    carr = np.pi * kt * ((eta - eta_ref) ** 2)
+
+    return carr
+
+
+def polyfit(xin, yin, zin, azimuth_order, range_order,
+            sig=None, snr=None, cond=1.0e-12,
+            max_order=True):
+    """
+    Fit 2-D polynomial
+    Parameters:
+    xin: np.ndarray
+       Array locations along x direction
+    yin: np.ndarray
+       Array locations along y direction
+    zin: np.ndarray
+       Array locations along z direction
+    azimuth_order: int
+       Azimuth polynomial order
+    range_order: int
+       Slant range polynomial order
+    sig: -
+       ---------------------------
+    snr: float
+       Signal to noise ratio
+    cond: float
+       ---------------------------
+    max_order: bool
+       ---------------------------
+
+    Returns:
+    poly: isce3.core.Poly2D
+       class represents a polynomial function of range
+       'x' and azimuth 'y'
+    """
+    x = np.array(xin)
+    xmin = np.min(x)
+    xnorm = np.max(x) - xmin
+    if xnorm == 0:
+        xnorm = 1.0
+    x = (x - xmin) / xnorm
+
+    y = np.array(yin)
+    ymin = np.min(y)
+    ynorm = np.max(y) - ymin
+    if ynorm == 0:
+        ynorm = 1.0
+    y = (y - ymin) / ynorm
+
+    z = np.array(zin)
+    big_order = max(azimuth_order, range_order)
+
+    arr_list = []
+    for ii in range(azimuth_order + 1):
+        yfact = np.power(y, ii)
+        for jj in range(range_order + 1):
+            xfact = np.power(x, jj) * yfact
+            if max_order:
+                if ((ii + jj) <= big_order):
+                    arr_list.append(xfact.reshape((x.size, 1)))
+            else:
+                arr_list.append(xfact.reshape((x.size, 1)))
+
+    A = np.hstack(arr_list)
+    if sig is not None and snr is not None:
+        raise Exception('Only one of sig / snr can be provided')
+    if sig is not None:
+        snr = 1.0 + 1.0 / sig
+    if snr is not None:
+        A = A / snr[:, None]
+        z = z / snr
+    return_val = True
+
+    val, res, rank, eigs = np.linalg.lstsq(A, z, rcond=cond)
+    if len(res) > 0:
+        print('Chi squared: %f' % (np.sqrt(res / (1.0 * len(z)))))
+    else:
+        print('No chi squared value....')
+        print('Try reducing rank of polynomial.')
+        return_val = False
+
+    coeffs = []
+    count = 0
+    for ii in range(azimuth_order + 1):
+        row = []
+        for jj in range(range_order + 1):
+            if max_order:
+                if (ii + jj) <= big_order:
+                    row.append(val[count])
+                    count = count + 1
+                else:
+                    row.append(0.0)
+            else:
+                row.append(val[count])
+                count = count + 1
+        coeffs.append(row)
+    poly = isce3.core.Poly2d(coeffs, xmin, ymin, xnorm, ynorm)
+    return poly
+
 
 @dataclass(frozen=True)
 class Doppler:
@@ -14,7 +165,7 @@ class Doppler:
 class Sentinel1BurstSlc:
     '''Raw values extracted from SAFE XML.
     '''
-    sensing_start: datetime.datetime# *
+    sensing_start: datetime.datetime
     radar_center_frequency: float
     wavelength: float
     azimuth_steer_rate: float
@@ -117,3 +268,42 @@ class Sentinel1BurstSlc:
         '''
         d_seconds = 0.5 * (self.shape[0] - 1) * self.azimuth_time_interval
         return self.sensing_start + datetime.timedelta(seconds=d_seconds)
+
+    def get_az_carrier_poly(self, offset=0.0, xstep=500, ystep=50,
+                            az_order=5, rg_order=3):
+        """
+        Estimate burst azimuth carrier polymonials
+        Parameters
+        ----------
+        offset: float
+            Offset between reference and secondary bursts
+        xstep: int
+            Spacing along x direction
+        ystep: int
+            Spacing along y direction
+        az_order: int
+            Azimuth polynomial order
+        rg_order: int
+            Slant range polynomial order
+
+        Returns
+        -------
+        poly: isce3.core.Poly2D
+           class represents a polynomial function of range
+           'x' and azimuth 'y'
+        """
+
+        lines, samples = self.shape
+        x = np.arange(0, samples, xstep, dtype=int)
+        y = np.arange(0, lines, ystep, dtype=int)
+        xx, yy = np.meshgrid(x, y)
+
+        # Estimate azimuth carrier
+        az_carrier = compute_az_carrier(self, self.orbit,
+                                        offset=offset,
+                                        position=(yy, xx))
+        # Estimate azimuth carrier polynomials
+        az_carrier_poly = polyfit(xx.flatten() + 1, yy.flatten() + 1,
+                                  az_carrier.flatten(), az_order,
+                                  rg_order)
+        return az_carrier_poly

--- a/src/sentinel1_reader/sentinel1_orbit_reader.py
+++ b/src/sentinel1_reader/sentinel1_orbit_reader.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+import datetime as datetime
 import os
 
 # date format used in file names
@@ -31,7 +31,7 @@ def get_file_name_tokens(zip_path: str) -> [str, list[datetime]]:
         ValueError(err_str)
 
     # extract start/stop time as a list[datetime]: [t_start, t_stop]
-    t_swath_start_stop = [datetime.strptime(t, FMT)
+    t_swath_start_stop = [datetime.datetime.strptime(t, FMT)
                           for t in file_name_tokens[5:7]]
 
     return platform_id, t_swath_start_stop

--- a/src/sentinel1_reader/sentinel1_orbit_reader.py
+++ b/src/sentinel1_reader/sentinel1_orbit_reader.py
@@ -1,10 +1,10 @@
-import datetime as datetime
+import datetime
 import os
 
 # date format used in file names
 FMT = "%Y%m%dT%H%M%S"
 
-def get_file_name_tokens(zip_path: str) -> [str, list[datetime]]:
+def get_file_name_tokens(zip_path: str) -> [str, list[datetime.datetime]]:
     '''Extract swath platform ID and start/stop times from SAFE zip file path.
 
     Parameters:
@@ -19,7 +19,7 @@ def get_file_name_tokens(zip_path: str) -> [str, list[datetime]]:
     platform_id: ('S1A', 'S1B')
     orbit_path : str
         Path the orbit file.
-    t_swath_start_stop: list[datetime]
+    t_swath_start_stop: list[datetime.datetime]
         Swath start/stop times
     '''
     file_name_tokens = os.path.basename(zip_path).split('_')
@@ -30,7 +30,7 @@ def get_file_name_tokens(zip_path: str) -> [str, list[datetime]]:
         err_str = f'{platform_id} not S1A nor S1B'
         ValueError(err_str)
 
-    # extract start/stop time as a list[datetime]: [t_start, t_stop]
+    # extract start/stop time as a list[datetime.datetime]: [t_start, t_stop]
     t_swath_start_stop = [datetime.datetime.strptime(t, FMT)
                           for t in file_name_tokens[5:7]]
 

--- a/src/sentinel1_reader/sentinel1_orbit_reader.py
+++ b/src/sentinel1_reader/sentinel1_orbit_reader.py
@@ -78,10 +78,10 @@ def get_swath_orbit_file_from_list(zip_path: str, orbit_file_list: list[str]) ->
         t_orbit_start, t_orbit_end = os.path.basename(orbit_file).split('_')[-2:]
 
         # strip 'V' at start of start time string
-        t_orbit_start = datetime.strptime(t_orbit_start[1:], FMT)
+        t_orbit_start = datetime.datetime.strptime(t_orbit_start[1:], FMT)
 
         # string '.EOF' from end of end time string
-        t_orbit_end = datetime.strptime(t_orbit_end[:-4], FMT)
+        t_orbit_end = datetime.datetime.strptime(t_orbit_end[:-4], FMT)
 
         # check if:
         # 1. swath start and stop time > orbit file start time

--- a/src/sentinel1_reader/sentinel1_reader.py
+++ b/src/sentinel1_reader/sentinel1_reader.py
@@ -1,4 +1,4 @@
-import datetime as datetime
+import datetime
 import os
 import xml.etree.ElementTree as ET
 import zipfile

--- a/src/sentinel1_reader/sentinel1_reader.py
+++ b/src/sentinel1_reader/sentinel1_reader.py
@@ -1,4 +1,4 @@
-import datetime
+import datetime as datetime
 import os
 import xml.etree.ElementTree as ET
 import zipfile


### PR DESCRIPTION
This PR adds the functionality of computing the azimuth carrier polynomials to the S1 reader for each burst (if requested).

This functionality will be needed for both COMPASS range/Doppler and geocoded CSLC workflow. To avoid code duplication, it makes sense that this functionality sits in the reader.

Note: the `polyfit` function in `sentinel1_burst_slc.py `needs help for the documentation.
