### PR TITLE
prepend listdir results with path

### DIFF
--- a/src/sentinel1_reader/sentinel1_orbit_reader.py
+++ b/src/sentinel1_reader/sentinel1_orbit_reader.py
@@ -117,6 +117,7 @@ def get_swath_orbit_file_from_dir(zip_path: str, orbit_dir: str) -> str:
     if not os.path.isdir(orbit_dir):
         raise NotADirectoryError(f"{orbit_dir} not found")
 
-    orbit_path = get_swath_orbit_file_from_list(zip_path, os.listdir(orbit_dir))
+    orbit_path = get_swath_orbit_file_from_list(
+        zip_path, [f'{orbit_dir}/{item}' for item in os.listdir(orbit_dir)])
 
     return orbit_path


### PR DESCRIPTION
`os.listdir` [here](https://github.com/opera-adt/sentinel1-reader/blob/6eb464a392867352b895d0497cfcd040625ce011/src/sentinel1_reader/sentinel1_orbit_reader.py#L120) provides items without any reference to the source directory. The lack of a directory in the path breaks `get_swath_orbit_file_list` [here](https://github.com/opera-adt/sentinel1-reader/blob/6eb464a392867352b895d0497cfcd040625ce011/src/sentinel1_reader/sentinel1_orbit_reader.py#L41) and [here](https://github.com/opera-adt/sentinel1-reader/blob/6eb464a392867352b895d0497cfcd040625ce011/src/sentinel1_reader/sentinel1_orbit_reader.py#L74).