### PR TITLE
add carrier poly fit againt az/rng

### DIFF
--- a/src/sentinel1_reader/sentinel1_burst_slc.py
+++ b/src/sentinel1_reader/sentinel1_burst_slc.py
@@ -339,8 +339,8 @@ class Sentinel1BurstSlc:
         # Fit azimuth carrier polynomial with with x/y or range/azimuth
         if index_as_coord:
             az_carrier_poly = polyfit(x_mesh.flatten()+1, y_mesh.flatten()+1,
-                                  az_carrier.flatten(), az_order,
-                                  rg_order)
+                                      az_carrier.flatten(), az_order,
+                                      rg_order)
         else:
             # Convert x/y to range/azimuth
             rg = self.starting_range + (x + 1) * self.range_pixel_spacing

--- a/src/sentinel1_reader/sentinel1_burst_slc.py
+++ b/src/sentinel1_reader/sentinel1_burst_slc.py
@@ -336,14 +336,20 @@ class Sentinel1BurstSlc:
                                         offset=offset,
                                         position=(y_mesh, x_mesh))
 
-        # Change index mesh to range/az mesh?
-        if not index_as_coord:
-            rg = self.starting_range + (x + 1) * self.range_pixel_spacing
-            az = rdr_grid.sensing_start + (y + 1) * self.azimuth_time_interval
-            x_mesh, y_mesh = np.meshgrid(rg, az)
-
-        # Estimate azimuth carrier polynomials
-        az_carrier_poly = polyfit(x_mesh.flatten(), y_mesh.flatten(),
+        # Fit azimuth carrier polynomial with with x/y or range/azimuth
+        if index_as_coord:
+            az_carrier_poly = polyfit(x_mesh.flatten()+1, y_mesh.flatten()+1,
                                   az_carrier.flatten(), az_order,
                                   rg_order)
+        else:
+            # Convert x/y to range/azimuth
+            rg = self.starting_range + (x + 1) * self.range_pixel_spacing
+            az = rdr_grid.sensing_start + (y + 1) * self.azimuth_time_interval
+            rg_mesh, az_mesh = np.meshgrid(rg, az)
+
+            # Estimate azimuth carrier polynomials
+            az_carrier_poly = polyfit(rg_mesh.flatten(), az_mesh.flatten(),
+                                  az_carrier.flatten(), az_order,
+                                  rg_order)
+
         return az_carrier_poly

--- a/src/sentinel1_reader/sentinel1_burst_slc.py
+++ b/src/sentinel1_reader/sentinel1_burst_slc.py
@@ -336,7 +336,7 @@ class Sentinel1BurstSlc:
                                         offset=offset,
                                         position=(y_mesh, x_mesh))
 
-        # Fit azimuth carrier polynomial with with x/y or range/azimuth
+        # Fit azimuth carrier polynomial with x/y or range/azimuth
         if index_as_coord:
             az_carrier_poly = polyfit(x_mesh.flatten()+1, y_mesh.flatten()+1,
                                       az_carrier.flatten(), az_order,


### PR DESCRIPTION
This PR gives `SentinelBurstSlc.get_az_carrier_poly` the ability to `polyfit` against azimuth and range values to allow for `carrier.eval(az, rng)`. This makes the `SentinelBurstSlc` carrier consistent with ISCE3 convention. Current use of use of `eval` only allows for azimuth and range indices as `eval` parameters.